### PR TITLE
Strip message edit tags in SkypeTextMsg.plain and .markup

### DIFF
--- a/skpy/msg.py
+++ b/skpy/msg.py
@@ -331,6 +331,7 @@ class SkypeTextMsg(SkypeMsg):
         text = re.sub(r"</?(e|b|i|ss?|pre|quote|legacyquote)\b.*?>", "", self.content)
         text = re.sub(r"""<a\b.*?href="(.*?)">.*?</a>""", r"\1", text)
         text = re.sub(r"""<at\b.*?id="8:(.*?)">.*?</at>""", r"@\1", text)
+        text = re.sub(r"""<e_m\b.*?>.*?</e_m>""", r"", text)
         text = (text.replace("&lt;", "<").replace("&gt;", ">").replace("&amp;", "&")
                     .replace("&quot;", "\"").replace("&apos;", "'"))
         return text
@@ -346,6 +347,7 @@ class SkypeTextMsg(SkypeMsg):
         text = re.sub(r"</?pre\b.*?>", "{code}", text)
         text = re.sub(r"""<a\b.*?href="(.*?)">.*?</a>""", r"\1", text)
         text = re.sub(r"""<at\b.*?id="8:(.*?)">.*?</at>""", r"@\1", text)
+        text = re.sub(r"""<e_m\b.*?>.*?</e_m>""", r"", text)
         text = (text.replace("&lt;", "<").replace("&gt;", ">").replace("&amp;", "&")
                     .replace("&quot;", "\"").replace("&apos;", "'"))
         return text


### PR DESCRIPTION
I noticed that an edited message contains, in its contents, something like:
<e_m a="USER" ts_ms="INT" ts = "INT"></e_m>
and that this tag is not filtered out by the plain and markup functions of SkypeTextMsg, despite the comment indicating that message edit tags are stripped.

The change in this PR strips this tag from the text.