### PR TITLE
Resolves 404 error when updating the avatar

### DIFF
--- a/skpy/conn.py
+++ b/skpy/conn.py
@@ -127,6 +127,7 @@ class SkypeConnection(SkypeObj):
     API_MSACC = "https://login.live.com"
     API_EDGE = "https://edge.skype.com/rps/v1/rps/skypetoken"
     API_USER = "https://api.skype.com"
+    API_AVATAR = "https://avatar.skype.com"
     API_PROFILE = "https://profile.skype.com/profile/v1"
     API_OPTIONS = "https://options.skype.com/options/v1/users/self/options"
     API_JOIN = "https://join.skype.com"

--- a/skpy/main.py
+++ b/skpy/main.py
@@ -141,8 +141,8 @@ class Skype(SkypeObj):
         Args:
             image (file): a file-like object to read the image from
         """
-        self.conn("PUT", "{0}/users/{1}/profile/avatar".format(SkypeConnection.API_USER, self.userId),
-                  auth=SkypeConnection.Auth.SkypeToken, data=image.read())
+        self.conn("PUT", "{0}/v1/avatars/{1}".format(SkypeConnection.API_AVATAR, self.userId),
+                  auth=SkypeConnection.Auth.SkypeToken, data=image.read(), headers={'Content-type': 'image/jpeg'})
 
     def getUrlMeta(self, url):
         """


### PR DESCRIPTION
setAvatar uses the wrong endpoint and throws a 404 error. This commit updates the endpoint and sets the correct header in order to upload the avatar