### PR TITLE
Solves HTTP_403 when searching for contacts. Change DIRECTORY URL and add missing headers

### DIFF
--- a/skpy/conn.py
+++ b/skpy/conn.py
@@ -1,18 +1,18 @@
+import base64
+import functools
+import hashlib
 import os
 import re
-import functools
-from datetime import datetime, timedelta
 import time
-from types import MethodType
-import hashlib
-import base64
+from datetime import datetime, timedelta
 from pprint import pformat
+from types import MethodType
 from xml.etree import ElementTree
 
-from bs4 import BeautifulSoup
 import requests
+from bs4 import BeautifulSoup
 
-from .core import SkypeObj, SkypeEnum, SkypeApiException, SkypeAuthException
+from .core import SkypeApiException, SkypeAuthException, SkypeEnum, SkypeObj
 
 
 class SkypeConnection(SkypeObj):
@@ -141,9 +141,11 @@ class SkypeConnection(SkypeObj):
     API_URL = "https://urlp.asm.skype.com/v1/url/info"
     API_CONTACTS = "https://contacts.skype.com/contacts/v2"
     API_MSGSHOST = "https://client-s.gateway.messenger.live.com/v1"
-    API_DIRECTORY = "https://skypegraph.skype.com/search/v1.1/namesearch/swx/"
+    API_DIRECTORY = "https://skypegraph.skype.com/v2.0/search/"
     # Version doesn't seem to be important, at least not for what we need.
     API_CONFIG = "https://a.config.skype.com/config/v1"
+    USER_AGENT = "SkPy"
+    SKYPE_CLIENT = "1418/9.99.0.999"
 
     attrs = ("userId", "tokenFile", "connected", "guest")
 
@@ -218,6 +220,10 @@ class SkypeConnection(SkypeObj):
         debugHeaders = dict(headers)
         if auth == self.Auth.SkypeToken:
             headers["X-SkypeToken"] = self.tokens["skype"]
+            headers["X-Ecs-Etag"] = self.ECS_ETAG
+            headers["X-Skype-Client"] = self.SKYPE_CLIENT
+            headers["X-Skypegraphservicesettings"] = str(self.SKYPE_GRAPH_SETTINGS)
+            headers["User-Agent"] = self.USER_AGENT
             debugHeaders["X-SkypeToken"] = "***"
         elif auth == self.Auth.Authorize:
             headers["Authorization"] = "skype_token {0}".format(self.tokens["skype"])

--- a/skpy/conn.py
+++ b/skpy/conn.py
@@ -149,7 +149,8 @@ class SkypeConnection(SkypeObj):
 
     attrs = ("userId", "tokenFile", "connected", "guest")
 
-    extSess = requests.session()
+    extSess = requests.Session()
+    extSess.headers["User-Agent"] = USER_AGENT
 
     def __init__(self):
         """
@@ -162,6 +163,7 @@ class SkypeConnection(SkypeObj):
         self.hasUserPwd = False
         self.msgsHost = self.API_MSGSHOST
         self.sess = requests.Session()
+        self.sess.headers["User-Agent"] = self.USER_AGENT
         self.endpoints = {"self": SkypeEndpoint(self, "SELF")}
         self.syncStates = {}
 
@@ -220,10 +222,6 @@ class SkypeConnection(SkypeObj):
         debugHeaders = dict(headers)
         if auth == self.Auth.SkypeToken:
             headers["X-SkypeToken"] = self.tokens["skype"]
-            headers["X-Ecs-Etag"] = self.ECS_ETAG
-            headers["X-Skype-Client"] = self.SKYPE_CLIENT
-            headers["X-Skypegraphservicesettings"] = str(self.SKYPE_GRAPH_SETTINGS)
-            headers["User-Agent"] = self.USER_AGENT
             debugHeaders["X-SkypeToken"] = "***"
         elif auth == self.Auth.Authorize:
             headers["Authorization"] = "skype_token {0}".format(self.tokens["skype"])


### PR DESCRIPTION
Fixes #226 
- Adds custom `User_Agent` header. Default Python requests header , is the culprit of the 403
- Adds the new v.2.0 Directory API url
- Add new HTTP headers (`X-Skype-Client`, `X-SkypeGraphServiceSettings`, `X-ECS-ETag`)